### PR TITLE
Update libdill instructions to allow building with later versions of gfortran

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.a
+*.mod
+*.o
+client
+server
+libdill

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ client: client.f90 $(OBJS)
 server: server.f90 $(OBJS)
 	$(FC) $(FCFLAGS) $< -o $@ libdill.a -pthread
 
-libdill-2.14:
-	curl http://libdill.org/libdill-2.14.tar.gz | tar xz
+libdill:
+	git clone https://github.com/sustrik/libdill
 
-libdill.a: libdill-2.14
-	cd libdill-2.14 && ./configure && make && cp .libs/libdill.a ..
+libdill.a: libdill
+	cd libdill && ./autogen.sh && ./configure && $(MAKE) && cp .libs/libdill.a ..
 
 .f90.o:
 	$(FC) $(FCFLAGS) -c $<

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Companion code for Chapter 11 of [Modern Fortran: Building Efficient Parallel Ap
 
 It uses [libdill](http://libdill.org) as a sockets library.
 
+Please note that the install instructions from the book (downloading
+libdill-2.14) do not work with gfortran v9.x or later.
+The download and install procedure for libdill has been updated in this repo
+to allow building with the latest versions of gfortran.
+
 ## Getting started
 
 Download and build the code:


### PR DESCRIPTION
Closes #1.